### PR TITLE
Fix typo in dompdf config comment

### DIFF
--- a/config/dompdf.php
+++ b/config/dompdf.php
@@ -84,7 +84,7 @@ return [
          * Protocol whitelist
          *
          * Protocols and PHP wrappers allowed in URIs, and the validation rules
-         * that determine if a resouce may be loaded. Full support is not guaranteed
+         * that determine if a resource may be loaded. Full support is not guaranteed
          * for the protocols/wrappers specified
          * by this array.
          *


### PR DESCRIPTION
## Summary
- correct a comment typo in `config/dompdf.php`

## Testing
- `grep -n "resource" -n config/dompdf.php`


------
https://chatgpt.com/codex/tasks/task_e_6887257a5ff4832c86c2d9fe20ad1301