### PR TITLE
Add timed sale functionality

### DIFF
--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -55,9 +55,11 @@ class ProductController extends Controller
         $request->validate([
             'name_ar' => 'required|string|max:255',
             'sku' => 'required|string|max:255|unique:products,sku',
-            // ... other validations
-            'images' => 'required|array', // Validate that 'images' is an array
-            'images.*' => 'image|mimes:jpeg,png,jpg,gif,svg,webp|max:2048', // Validate each image
+            'sale_price' => 'nullable|numeric|min:0',
+            'sale_starts_at' => 'nullable|date',
+            'sale_ends_at' => 'nullable|date|after_or_equal:sale_starts_at',
+            'images' => 'required|array',
+            'images.*' => 'image|mimes:jpeg,png,jpg,gif,svg,webp|max:2048',
         ]);
 
         DB::beginTransaction();
@@ -96,8 +98,10 @@ class ProductController extends Controller
         $request->validate([
             'name_ar' => 'required|string|max:255',
             'sku' => 'required|string|max:255|unique:products,sku,' . $product->id,
-            // ... other validations
-            'images' => 'nullable|array', // Images are not required on update
+            'sale_price' => 'nullable|numeric|min:0',
+            'sale_starts_at' => 'nullable|date',
+            'sale_ends_at' => 'nullable|date|after_or_equal:sale_starts_at',
+            'images' => 'nullable|array',
             'images.*' => 'image|mimes:jpeg,png,jpg,gif,svg,webp|max:2048',
         ]);
 

--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -30,7 +30,7 @@ class CartController extends Controller
                         'product' => $product,
                         'quantity' => $details['quantity'],
                     ];
-                    $total += $product->price * $details['quantity'];
+                    $total += $product->current_price * $details['quantity'];
                 } else {
                     // إذا كان المنتج في السلة ولكنه غير موجود في قاعدة البيانات، قم بإزالته
                     unset($cart[$id]);
@@ -144,7 +144,7 @@ class CartController extends Controller
                 $items[] = [
                     'product_id' => $product->id,
                     'category_id' => $product->category_id,
-                    'price' => $product->price,
+                    'price' => $product->current_price,
                     'quantity' => $details['quantity'],
                 ];
             }

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -35,7 +35,7 @@ class CheckoutController extends Controller
         foreach ($cart as $id => $details) {
             if (isset($products[$id])) {
                 $product = $products[$id];
-                $price = $product->sale_price ?? $product->price;
+                $price = $product->current_price;
                 $cartItems[$id] = [
                     'product' => $product,
                     'quantity' => $details['quantity'],
@@ -90,7 +90,7 @@ public function store(Request $request, InventoryService $inventoryService)
         foreach ($cart as $id => $details) {
             if (isset($products[$id])) {
                 $product = $products[$id];
-                $price = $product->sale_price ?? $product->price;
+                $price = $product->current_price;
                 $subtotal += $price * $details['quantity'];
             }
         }
@@ -132,7 +132,7 @@ public function store(Request $request, InventoryService $inventoryService)
         foreach ($cart as $id => $details) {
             if (isset($products[$id])) {
                 $product = $products[$id];
-                $price = $product->sale_price ?? $product->price;
+                $price = $product->current_price;
 
                 // خصم الكمية من المخزون (حسب دالة الـ InventoryService)
                 $itemCost = $inventoryService->deductStock($product, $details['quantity']);

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -25,6 +25,14 @@ class PageController extends Controller
         $saleProducts = Product::where('is_active', true)
             ->whereNotNull('sale_price')
             ->where('sale_price', '>', 0)
+            ->where(function ($q) {
+                $now = now();
+                $q->whereNull('sale_starts_at')->orWhere('sale_starts_at', '<=', $now);
+            })
+            ->where(function ($q) {
+                $now = now();
+                $q->whereNull('sale_ends_at')->orWhere('sale_ends_at', '>=', $now);
+            })
             ->with('firstImage')
             ->inRandomOrder()
             ->take(14)
@@ -94,7 +102,16 @@ class PageController extends Controller
 
         // On-sale filter
         if ($request->boolean('on_sale')) {
-            $query->whereNotNull('sale_price')->where('sale_price', '>', 0);
+            $query->whereNotNull('sale_price')
+                  ->where('sale_price', '>', 0)
+                  ->where(function ($q) {
+                      $now = now();
+                      $q->whereNull('sale_starts_at')->orWhere('sale_starts_at', '<=', $now);
+                  })
+                  ->where(function ($q) {
+                      $now = now();
+                      $q->whereNull('sale_ends_at')->orWhere('sale_ends_at', '>=', $now);
+                  });
         }
 
         // Get products with sorting and pagination

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -21,8 +21,15 @@ class Product extends Model
         'description_ku',
         'price',
         'sale_price',
+        'sale_starts_at',
+        'sale_ends_at',
         'image_url',
         'is_active', // <-- تمت الإضافة هنا
+    ];
+
+    protected $casts = [
+        'sale_starts_at' => 'datetime',
+        'sale_ends_at' => 'datetime',
     ];
 
     /**
@@ -103,5 +110,25 @@ class Product extends Model
     public function firstImage()
     {
         return $this->hasOne(ProductImage::class)->oldestOfMany();
+    }
+
+    /**
+     * Determine if the product is currently on sale.
+     */
+    public function isOnSale(): bool
+    {
+        $now = now();
+        return $this->sale_price !== null
+            && $this->sale_price > 0
+            && ($this->sale_starts_at === null || $this->sale_starts_at <= $now)
+            && ($this->sale_ends_at === null || $this->sale_ends_at >= $now);
+    }
+
+    /**
+     * Get the price taking into account any active sale.
+     */
+    public function getCurrentPriceAttribute(): float
+    {
+        return $this->isOnSale() ? $this->sale_price : $this->price;
     }
 }

--- a/database/migrations/2025_07_30_000000_add_sale_dates_to_products_table.php
+++ b/database/migrations/2025_07_30_000000_add_sale_dates_to_products_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->timestamp('sale_starts_at')->nullable()->after('sale_price');
+            $table->timestamp('sale_ends_at')->nullable()->after('sale_starts_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn(['sale_starts_at', 'sale_ends_at']);
+        });
+    }
+};

--- a/resources/views/admin/products/_form.blade.php
+++ b/resources/views/admin/products/_form.blade.php
@@ -88,6 +88,22 @@
                 </div>
 
                 <div class="mb-3">
+                    <label for="sale_starts_at" class="form-label">تاريخ بدء الخصم</label>
+                    <input type="datetime-local" class="form-control @error('sale_starts_at') is-invalid @enderror" id="sale_starts_at" name="sale_starts_at" value="{{ old('sale_starts_at', isset($product) && $product->sale_starts_at ? $product->sale_starts_at->format('Y-m-d\TH:i') : '') }}">
+                    @error('sale_starts_at')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+
+                <div class="mb-3">
+                    <label for="sale_ends_at" class="form-label">تاريخ انتهاء الخصم</label>
+                    <input type="datetime-local" class="form-control @error('sale_ends_at') is-invalid @enderror" id="sale_ends_at" name="sale_ends_at" value="{{ old('sale_ends_at', isset($product) && $product->sale_ends_at ? $product->sale_ends_at->format('Y-m-d\TH:i') : '') }}">
+                    @error('sale_ends_at')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+
+                <div class="mb-3">
                     <label for="category_id" class="form-label">القسم <span class="text-danger">*</span></label>
                     <select class="form-select @error('category_id') is-invalid @enderror" id="category_id" name="category_id" required>
                         <option value="">-- اختر القسم --</option>

--- a/resources/views/frontend/homepage.blade.php
+++ b/resources/views/frontend/homepage.blade.php
@@ -115,7 +115,7 @@
         </div>
         <div class="products-grid">
             @foreach($newProducts->take(14) as $product)
-                <div class="product-card @if($product->sale_price && $product->sale_price > 0) sale-product-highlight @endif" x-data="{
+                <div class="product-card @if($product->isOnSale()) sale-product-highlight @endif" x-data="{
                     added: false,
                     loadingAdd: false,
                     isFavorite: {{ in_array($product->id, $favoriteProductIds ?? []) ? 'true' : 'false' }},
@@ -129,7 +129,7 @@
                                 <img src="https://placehold.co/400x400?text=No+Image" class="w-full h-full object-cover">
                             @endif
                         </div>
-                        @if($product->sale_price && $product->sale_price > 0)
+                        @if($product->isOnSale())
                             @php
                                 $discountPercentage = round((($product->price - $product->sale_price) / $product->price) * 100);
                             @endphp
@@ -167,7 +167,7 @@
                             @endauth
                         </div>
                         <div class="mb-3">
-                            @if($product->sale_price && $product->sale_price > 0)
+                            @if($product->isOnSale())
                                 <span class="text-brand-primary font-bold text-lg">{{ number_format($product->sale_price, 0) }} د.ع</span>
                                 <span class="text-gray-400 line-through text-sm ml-2">{{ number_format($product->price, 0) }} د.ع</span>
                             @else
@@ -233,7 +233,7 @@
                                 <img src="https://placehold.co/400x400?text=No+Image" class="w-full h-full object-cover">
                             @endif
                         </div>
-                        @if($product->sale_price && $product->sale_price > 0)
+                        @if($product->isOnSale())
                             @php
                                 $discountPercentage = round((($product->price - $product->sale_price) / $product->price) * 100);
                             @endphp
@@ -266,7 +266,7 @@
                             @endauth
                         </div>
                         <div class="mb-3">
-                            @if($product->sale_price && $product->sale_price > 0)
+                            @if($product->isOnSale())
                                 <span class="text-brand-primary font-bold text-lg">{{ number_format($product->sale_price, 0) }} د.ع</span>
                                 <span class="text-gray-400 line-through text-sm ml-2">{{ number_format($product->price, 0) }} د.ع</span>
                             @else
@@ -314,7 +314,7 @@
         </div>
         <div class="products-grid">
             @foreach($bestSellingProducts->take(14) as $product)
-                <div class="product-card @if($product->sale_price && $product->sale_price > 0) sale-product-highlight @endif" x-data="{
+                <div class="product-card @if($product->isOnSale()) sale-product-highlight @endif" x-data="{
                     added: false,
                     loadingAdd: false,
                     isFavorite: {{ in_array($product->id, $favoriteProductIds ?? []) ? 'true' : 'false' }},
@@ -328,7 +328,7 @@
                                 <img src="https://placehold.co/400x400?text=No+Image" class="w-full h-full object-cover">
                             @endif
                         </div>
-                        @if($product->sale_price && $product->sale_price > 0)
+                        @if($product->isOnSale())
                             @php
                                 $discountPercentage = round((($product->price - $product->sale_price) / $product->price) * 100);
                             @endphp
@@ -361,7 +361,7 @@
                             @endauth
                         </div>
                         <div class="mb-3">
-                            @if($product->sale_price && $product->sale_price > 0)
+                            @if($product->isOnSale())
                                 <span class="text-brand-primary font-bold text-lg">{{ number_format($product->sale_price, 0) }} د.ع</span>
                                 <span class="text-gray-400 line-through text-sm ml-2">{{ number_format($product->price, 0) }} د.ع</span>
                             @else

--- a/resources/views/frontend/product-detail.blade.php
+++ b/resources/views/frontend/product-detail.blade.php
@@ -76,7 +76,7 @@
                 <span class="text-sm text-gray-500 mb-4">SKU: {{ $product->sku ?? 'N/A' }}</span>
 
                 <div class="mb-6">
-                    @if($product->sale_price && $product->sale_price > 0)
+                    @if($product->isOnSale())
                         <span class="text-brand-primary font-bold text-3xl">{{ number_format($product->sale_price, 0) }} د.ع</span>
                         <span class="text-gray-400 line-through text-xl ml-3">{{ number_format($product->price, 0) }} د.ع</span>
                     @else
@@ -183,7 +183,7 @@
         <h2 class="text-3xl font-bold text-brand-dark mb-8 text-center">ربما يعجبك أيضاً</h2>
         <div class="grid grid-cols-2 md:grid-cols-4 gap-6">
             @foreach($relatedProducts as $relatedProduct)
-                <div class="product-card @if($relatedProduct->sale_price && $relatedProduct->sale_price > 0) sale-product-highlight @endif" x-data="{
+                <div class="product-card @if($relatedProduct->isOnSale()) sale-product-highlight @endif" x-data="{
                     added: false,
                     loadingAdd: false,
                     isFavorite: {{ in_array($relatedProduct->id, $favoriteProductIds ?? []) ? 'true' : 'false' }},
@@ -197,7 +197,7 @@
                                 <img src="https://placehold.co/400x400?text=No+Image" class="w-full h-full object-cover">
                             @endif
                         </div>
-                        @if($relatedProduct->sale_price && $relatedProduct->sale_price > 0)
+                        @if($relatedProduct->isOnSale())
                             @php
                                 $discountPercentage = round((($relatedProduct->price - $relatedProduct->sale_price) / $relatedProduct->price) * 100);
                             @endphp
@@ -230,7 +230,7 @@
                             @endauth
                         </div>
                         <div class="mb-3">
-                            @if($relatedProduct->sale_price && $relatedProduct->sale_price > 0)
+                            @if($relatedProduct->isOnSale())
                                 <span class="text-brand-primary font-bold text-lg">{{ number_format($relatedProduct->sale_price, 0) }} د.ع</span>
                                 <span class="text-gray-400 line-through text-sm ml-2">{{ number_format($relatedProduct->price, 0) }} د.ع</span>
                             @else

--- a/resources/views/frontend/profile/wishlist.blade.php
+++ b/resources/views/frontend/profile/wishlist.blade.php
@@ -85,7 +85,7 @@
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
             @foreach ($favorites as $favorite)
                 @if ($product = $favorite->product)
-                <div class="product-card @if($product->sale_price && $product->sale_price > 0) sale-product-highlight @endif" 
+                <div class="product-card @if($product->isOnSale()) sale-product-highlight @endif"
                      x-data="{
                         added: false,
                         loadingAdd: false,
@@ -102,7 +102,7 @@
                                 <img src="https://placehold.co/400x400/f9f5f1/cd8985?text=No+Image" class="w-full h-full object-cover" loading="lazy">
                             @endif
                         </div>
-                        @if($product->sale_price && $product->sale_price > 0)
+                        @if($product->isOnSale())
                             @php
                                 $discountPercentage = round((($product->price - $product->sale_price) / $product->price) * 100);
                             @endphp
@@ -137,7 +137,7 @@
                             </button>
                         </div>
                         <div class="mb-2 md:mb-3 product-price">
-                            @if($product->sale_price && $product->sale_price > 0)
+                            @if($product->isOnSale())
                                 <span class="text-[#cd8985] font-bold text-base md:text-lg">{{ number_format($product->sale_price, 0) }} د.ع</span>
                                 <span class="text-[#9ca3af] line-through text-xs md:text-sm ml-2">{{ number_format($product->price, 0) }} د.ع</span>
                             @else

--- a/resources/views/frontend/shop.blade.php
+++ b/resources/views/frontend/shop.blade.php
@@ -82,7 +82,7 @@
         <div class="lg:col-span-4">
             <div class="products-grid">
                 @forelse ($products as $product)
-                    <div class="product-card @if($product->sale_price && $product->sale_price > 0) sale-product-highlight @endif" x-data="{
+                    <div class="product-card @if($product->isOnSale()) sale-product-highlight @endif" x-data="{
                         added: false,
                         loadingAdd: false,
                         isFavorite: {{ in_array($product->id, $favoriteProductIds) ? 'true' : 'false' }},
@@ -96,7 +96,7 @@
                                     <img src="https://placehold.co/400x400?text=No+Image" class="w-full h-full object-cover">
                                 @endif
                             </div>
-                            @if($product->sale_price && $product->sale_price > 0)
+                            @if($product->isOnSale())
                                 @php
                                     $discountPercentage = round((($product->price - $product->sale_price) / $product->price) * 100);
                                 @endphp
@@ -134,7 +134,7 @@
                                 @endauth
                             </div>
                             <div class="mb-3">
-                                @if($product->sale_price && $product->sale_price > 0)
+                                @if($product->isOnSale())
                                     <span class="text-brand-primary font-bold text-lg">{{ number_format($product->sale_price, 0) }} د.ع</span>
                                     <span class="text-gray-400 line-through text-sm ml-2">{{ number_format($product->price, 0) }} د.ع</span>
                                 @else


### PR DESCRIPTION
## Summary
- allow products to have `sale_starts_at` and `sale_ends_at` dates
- show sale price only when the sale period is active
- adjust cart, checkout, and shop views to use new logic

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68873501c8fc832cac9d6fa6e7e48d50