### PR TITLE
Fix cart links & track discount code usage

### DIFF
--- a/app/Http/Controllers/Admin/OrderController.php
+++ b/app/Http/Controllers/Admin/OrderController.php
@@ -211,6 +211,15 @@ class OrderController extends Controller
             $order->items()->createMany($orderItemsData);
             $order->update(['total_cost' => $totalCost]);
 
+            // سجل استخدام كود الخصم إن وجد
+            if ($discountCodeId) {
+                \App\Models\DiscountCodeUsage::create([
+                    'discount_code_id' => $discountCodeId,
+                    'user_id' => auth()->id(),
+                    'order_id' => $order->id,
+                ]);
+            }
+
             DB::commit();
 
             // إرسال إشعار للإدارة بوجود طلب جديد
@@ -330,6 +339,15 @@ class OrderController extends Controller
                 'discount_code_id' => $discountCodeId,
                 'total_cost' => $totalCost,
             ]);
+
+            // تحديث أو إنشاء سجل استخدام كود الخصم
+            if ($discountCodeId) {
+                \App\Models\DiscountCodeUsage::create([
+                    'discount_code_id' => $discountCodeId,
+                    'user_id' => auth()->id(),
+                    'order_id' => $order->id,
+                ]);
+            }
 
             DB::commit();
 

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -152,6 +152,15 @@ public function store(Request $request, InventoryService $inventoryService)
         // تحديث تكلفة المنتجات الإجمالية في الطلب
         $order->update(['total_cost' => $totalCost]);
 
+        // تسجيل استخدام كود الخصم إن وجد
+        if ($discountCodeId) {
+            \App\Models\DiscountCodeUsage::create([
+                'discount_code_id' => $discountCodeId,
+                'user_id' => $user->id,
+                'order_id' => $order->id,
+            ]);
+        }
+
         DB::commit();
 
         // إشعارات الطلب الجديد

--- a/resources/views/frontend/cart/index.blade.php
+++ b/resources/views/frontend/cart/index.blade.php
@@ -136,13 +136,13 @@
                     <div class="space-y-4">
                         <template x-for="item in Object.values(cartItems)" :key="item.product.id">
                             <div class="bg-white rounded-lg shadow-sm p-4 flex gap-4">
-                                <a :href="`/product/${item.product.slug}`" class="w-24 h-24 flex-shrink-0">
+                                <a :href="`/product/${item.product.id}`" class="w-24 h-24 flex-shrink-0">
                                     <img :src="item.product.first_image ? `/storage/${item.product.first_image.image_path}` : 'https://placehold.co/150x150?text=No+Image'" :alt="item.product.name_ar" class="w-full h-full object-cover rounded-md">
                                 </a>
                                 <div class="flex flex-col flex-grow w-full">
                                     <div class="flex justify-between items-start">
                                         <div>
-                                            <a :href="`/product/${item.product.slug}`" class="font-bold text-lg text-brand-text hover:text-brand-primary" x-text="item.product.name_ar"></a>
+                                            <a :href="`/product/${item.product.id}`" class="font-bold text-lg text-brand-text hover:text-brand-primary" x-text="item.product.name_ar"></a>
                                             <p class="text-sm text-gray-500">SKU: <span x-text="item.product.sku || 'N/A'"></span></p>
                                         </div>
                                         <button @click="removeItem(item.product.id)" class="text-gray-400 hover:text-red-500 transition" title="إزالة المنتج">


### PR DESCRIPTION
## Summary
- link cart products using IDs instead of slugs
- log discount code usage when orders are created or updated

## Testing
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_688748e5b598832c82e39938543aa88d