### PR TITLE
Enable localization with language switcher

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -35,6 +35,7 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
+            \App\Http\Middleware\SetLocale::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
@@ -68,5 +69,6 @@ class Kernel extends HttpKernel
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
         'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
+        'setlocale' => \App\Http\Middleware\SetLocale::class,
     ];
 }

--- a/config/app.php
+++ b/config/app.php
@@ -78,7 +78,7 @@ return [
     |
     */
 
-    'locale' => env('APP_LOCALE', 'en'),
+    'locale' => env('APP_LOCALE', 'ar'),
 
     'fallback_locale' => env('APP_FALLBACK_LOCALE', 'en'),
 

--- a/lang/ar/layout.php
+++ b/lang/ar/layout.php
@@ -12,6 +12,8 @@ return [
     'shop' => 'المتجر',
     'wishlist' => 'المفضلة',
     'cart' => 'عربة التسوق',
+    'login_register' => 'تسجيل الدخول أو الاشتراك',
+    'categories' => 'الاقسام',
     'information' => 'معلومات',
     'about_us' => 'من نحن',
     'how_to_order' => 'طريقة الطلب',

--- a/lang/en/layout.php
+++ b/lang/en/layout.php
@@ -12,6 +12,8 @@ return [
     'shop' => 'Shop',
     'wishlist' => 'Wishlist',
     'cart' => 'Shopping Cart',
+    'login_register' => 'Login / Register',
+    'categories' => 'Categories',
     'information' => 'Information',
     'about_us' => 'About Us',
     'how_to_order' => 'How to Order',

--- a/lang/ku/layout.php
+++ b/lang/ku/layout.php
@@ -12,6 +12,8 @@ return [
     'shop' => 'دوکان',
     'wishlist' => 'خوازراوەکان',
     'cart' => 'سەبەتەی کڕین',
+    'login_register' => 'چوونەژوورەوە/خۆتۆمارکردن',
+    'categories' => 'بەشەکان',
     'information' => 'زانیاری',
     'about_us' => 'دەربارەی ئێمە',
     'how_to_order' => 'چۆنیەتی داواکردن',

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <title>@yield('title', 'كوزميليا | Cosmelea')</title>
+    <title>@yield('title', __('layout.cosmelea') . ' | Cosmelea')</title>
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -142,11 +142,11 @@
             <div class="container mx-auto hidden md:flex items-center justify-between px-4 md:px-8 text-white font-semibold">
                 <a href="{{ route('homepage') }}" class="text-xl sm:text-2xl flex items-center gap-2 hover:opacity-90 transition">
                     <img src="https://cosmelea.com/storage/logo-white.png" alt="logo" class="w-10 h-10">
-                    <span class="text-white font-bold">كوزميليا</span>
+                    <span class="text-white font-bold">{{ __('layout.cosmelea') }}</span>
                 </a>
                 <form action="{{ route('products.search') }}" method="GET" class="flex flex-1 mx-6 max-w-2xl">
                     <div class="flex w-full bg-white rounded-full overflow-hidden">
-                        <input type="text" name="query" placeholder="ابحثي عن منتجاتك المفضلة..."
+                        <input type="text" name="query" placeholder="{{ __('layout.search_placeholder') }}"
                                class="flex-1 px-4 py-2 text-sm text-gray-700 placeholder-gray-500 focus:outline-none">
                         <button type="submit" class="px-4 bg-white text-[#be6661] hover:text-[#cd8985]">
                             <i class="bi bi-search text-lg"></i>
@@ -154,13 +154,18 @@
                     </div>
                 </form>
                 <div class="hidden md:flex items-center gap-4 text-white">
+                    <div class="flex gap-2">
+                        <a href="{{ route('lang.switch', 'ar') }}" class="hover:underline {{ app()->getLocale() == 'ar' ? 'font-bold' : '' }}">AR</a>
+                        <a href="{{ route('lang.switch', 'en') }}" class="hover:underline {{ app()->getLocale() == 'en' ? 'font-bold' : '' }}">EN</a>
+                        <a href="{{ route('lang.switch', 'ku') }}" class="hover:underline {{ app()->getLocale() == 'ku' ? 'font-bold' : '' }}">KU</a>
+                    </div>
                     @auth
                     <a href="{{ route('profile.show') }}" class="hover:opacity-80 transition relative group">
                         <i class="bi bi-person text-xl"></i>
                     </a>
                     @else
                     <a href="{{ route('login') }}" class="hover:underline hover:text-[#f9f5f1] transition text-sm">
-                        تسجيل الدخول أو الاشتراك
+                        {{ __('layout.login_register') }}
                     </a>
                     @endauth
                     <a href="{{ route('cart.index') }}" class="hover:opacity-80 transition relative">
@@ -180,11 +185,11 @@
             <div class="container mx-auto md:hidden flex flex-col items-center gap-3 px-4">
                  <a href="{{ route('homepage') }}" class="text-xl sm:text-2xl flex items-center gap-2 hover:opacity-90 transition text-white font-bold">
                     <img src="https://cosmelea.com/storage/logo-white.png" alt="logo" class="w-8 h-8">
-                    <span>كوزميليا</span>
+                    <span>{{ __('layout.cosmelea') }}</span>
                 </a>
                  <form action="{{ route('products.search') }}" method="GET" class="w-full">
                     <div class="flex w-full bg-white rounded-full overflow-hidden">
-                        <input type="text" name="query" placeholder="ابحثي عن منتجاتك المفضلة..."
+                        <input type="text" name="query" placeholder="{{ __('layout.search_placeholder') }}"
                                class="flex-1 px-4 py-2 text-sm text-gray-700 placeholder-gray-500 focus:outline-none">
                         <button type="submit" class="px-4 bg-white text-[#be6661] hover:text-[#cd8985]">
                             <i class="bi bi-search"></i>
@@ -206,7 +211,7 @@
             <div class="md:col-span-2 flex flex-col items-center md:items-start">
                 <a href="{{ route('homepage') }}" class="flex items-center justify-center md:justify-start gap-2 text-2xl font-bold text-[#be6661] mb-4">
                     <img src="https://cosmelea.com/storage/logo-black.png" alt="Cosmelea Logo" class="w-12 h-12">
-                    كوزميليا
+                    {{ __('layout.cosmelea') }}
                 </a>
                 <p class="leading-relaxed text-sm text-[#6B7280] max-w-md">
                     وجهتكِ الأولى لمنتجات التجميل الأصلية والعناية الفاخرة. نؤمن أن جمالكِ يستحق الأفضل دائمًا.
@@ -220,19 +225,19 @@
             <div>
                 <h3 class="text-lg font-semibold text-[#be6661] mb-4">روابط سريعة</h3>
                 <ul class="space-y-2">
-                    <li><a href="{{ route('homepage') }}" class="hover:text-[#cd8985]">الرئيسية</a></li>
-                    <li><a href="{{ route('shop') }}" class="hover:text-[#cd8985]">المتجر</a></li>
-                    <li><a href="{{ route('wishlist') }}" class="hover:text-[#cd8985]">المفضلة</a></li>
-                    <li><a href="{{ route('profile.show') }}" class="hover:text-[#cd8985]">حسابي</a></li>
+                    <li><a href="{{ route('homepage') }}" class="hover:text-[#cd8985]">{{ __('layout.home') }}</a></li>
+                    <li><a href="{{ route('shop') }}" class="hover:text-[#cd8985]">{{ __('layout.shop') }}</a></li>
+                    <li><a href="{{ route('wishlist') }}" class="hover:text-[#cd8985]">{{ __('layout.wishlist') }}</a></li>
+                    <li><a href="{{ route('profile.show') }}" class="hover:text-[#cd8985]">{{ __('layout.my_account') }}</a></li>
                 </ul>
             </div>
             <div>
-                <h3 class="text-lg font-semibold text-[#be6661] mb-4">معلومات</h3>
+                <h3 class="text-lg font-semibold text-[#be6661] mb-4">{{ __('layout.information') }}</h3>
                 <ul class="space-y-2">
-                    <li><a href="{{ route('about.us') }}" class="hover:text-[#cd8985]">من نحن</a></li>
-                    <li><a href="{{ route('privacy.policy') }}" class="hover:text-[#cd8985]">سياسة الخصوصية</a></li>
-                    <li><a href="{{ route('order.method') }}" class="hover:text-[#cd8985]">طريقة الطلب</a></li>
-                    <li><a href="#" class="hover:text-[#cd8985]">اتصل بنا</a></li>
+                    <li><a href="{{ route('about.us') }}" class="hover:text-[#cd8985]">{{ __('layout.about_us') }}</a></li>
+                    <li><a href="{{ route('privacy.policy') }}" class="hover:text-[#cd8985]">{{ __('layout.privacy_policy') }}</a></li>
+                    <li><a href="{{ route('order.method') }}" class="hover:text-[#cd8985]">{{ __('layout.how_to_order') }}</a></li>
+                    <li><a href="#" class="hover:text-[#cd8985]">{{ __('layout.contact_us') }}</a></li>
                 </ul>
             </div>
         </div>
@@ -247,13 +252,13 @@
             <a href="{{ route('homepage') }}" 
                class="py-3 flex flex-col items-center hover:bg-[#f9f5f1] {{ request()->routeIs('homepage') ? 'bg-[#ad574e] text-white font-bold hover:bg-[#be6661]' : '' }}">
                 <i class="bi bi-house-door text-xl"></i>
-                <span class="text-xs mt-1">الرئيسية</span>
+                <span class="text-xs mt-1">{{ __('layout.home') }}</span>
             </a>
             <!-- المتجر -->
             <a href="{{ route('shop') }}" 
                class="py-3 flex flex-col items-center hover:bg-[#f9f5f1] {{ request()->routeIs('shop') ? 'bg-[#ad574e] text-white font-bold hover:bg-[#be6661]' : '' }}">
                 <i class="bi bi-grid text-xl"></i>
-                <span class="text-xs mt-1">المتجر</span>
+                <span class="text-xs mt-1">{{ __('layout.shop') }}</span>
             </a>
             <!-- السلة -->
             <a href="{{ route('cart.index') }}" 
@@ -262,19 +267,19 @@
                     <i class="bi bi-bag text-xl"></i>
                     <span x-show="cartCount > 0" x-text="cartCount" class="badge" :class="{'animate-ping-once': isCartUpdated}" style="display: none;"></span>
                 </div>
-                <span class="text-xs mt-1">السلة</span>
+                <span class="text-xs mt-1">{{ __('layout.cart') }}</span>
             </a>
             <!-- الاقسام -->
             <a href="{{ route('categories.index') }}" 
                class="py-3 flex flex-col items-center hover:bg-[#f9f5f1] {{ request()->routeIs('categories.index') ? 'bg-[#ad574e] text-white font-bold hover:bg-[#be6661]' : '' }}">
                 <i class="bi bi-grid-3x3-gap text-xl"></i>
-                <span class="text-xs mt-1">الاقسام</span>
+                <span class="text-xs mt-1">{{ __('layout.categories') }}</span>
             </a>
             <!-- حسابي -->
             <a href="{{ route('profile.show') }}" 
                class="py-3 flex flex-col items-center hover:bg-[#f9f5f1] {{ request()->routeIs('profile.show') ? 'bg-[#ad574e] text-white font-bold hover:bg-[#be6661]' : '' }}">
                 <i class="bi bi-person text-xl"></i>
-                <span class="text-xs mt-1">حسابي</span>
+                <span class="text-xs mt-1">{{ __('layout.my_account') }}</span>
             </a>
         </div>
     </footer>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,8 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Auth; // موجود فقط بالكود الثاني
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Facades\App;
 
 // Frontend Controllers
 use App\Http\Controllers\HomeController;
@@ -50,6 +52,13 @@ Auth::routes(['verify' => true]);
 Route::get('/maintenance', function () {
     return view('frontend.maintenance');
 })->name('maintenance.page');
+
+Route::get('lang/{locale}', function ($locale) {
+    if (in_array($locale, ['ar', 'en', 'ku'])) {
+        Session::put('locale', $locale);
+    }
+    return redirect()->back();
+})->name('lang.switch');
 
 Route::get('/track-order', [OrderTrackingController::class, 'showTrackingForm'])->name('tracking.form');
 Route::post('/track-order', [OrderTrackingController::class, 'trackOrder'])->name('tracking.track');


### PR DESCRIPTION
## Summary
- set Arabic as default locale
- add SetLocale middleware
- add language switch route
- update layout with translations and a language switcher
- add translation strings for login/register and categories

## Testing
- `php artisan test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68874b079e58832ca4c07da4a12eeba8