### PR TITLE
Add multilingual product fields and translations

### DIFF
--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -75,6 +75,10 @@ class ProductController extends Controller
     {
         $request->validate([
             'name_ar' => 'required|string|max:255',
+            'name_en' => 'nullable|string|max:255',
+            'name_ku' => 'nullable|string|max:255',
+            'description_en' => 'nullable|string',
+            'description_ku' => 'nullable|string',
             'sku' => 'required|string|max:255|unique:products,sku',
             'sale_price' => 'nullable|numeric|min:0',
             'sale_starts_at' => 'nullable|date',
@@ -118,6 +122,10 @@ class ProductController extends Controller
     {
         $request->validate([
             'name_ar' => 'required|string|max:255',
+            'name_en' => 'nullable|string|max:255',
+            'name_ku' => 'nullable|string|max:255',
+            'description_en' => 'nullable|string',
+            'description_ku' => 'nullable|string',
             'sku' => 'required|string|max:255|unique:products,sku,' . $product->id,
             'sale_price' => 'nullable|numeric|min:0',
             'sale_starts_at' => 'nullable|date',

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -33,6 +33,26 @@ class Product extends Model
     ];
 
     /**
+     * Get the translated name based on the current locale.
+     */
+    public function getNameTranslatedAttribute(): string
+    {
+        $locale = app()->getLocale();
+        $value = $this->getAttribute('name_' . $locale);
+        return $value ?: $this->name_ar;
+    }
+
+    /**
+     * Get the translated description based on the current locale.
+     */
+    public function getDescriptionTranslatedAttribute(): string
+    {
+        $locale = app()->getLocale();
+        $value = $this->getAttribute('description_' . $locale);
+        return $value ?: $this->description_ar;
+    }
+
+    /**
      * العلاقة مع وجبات الشراء
      */
     public function purchaseItems()

--- a/resources/views/admin/products/_form.blade.php
+++ b/resources/views/admin/products/_form.blade.php
@@ -11,12 +11,40 @@
                         <div class="invalid-feedback">{{ $message }}</div>
                     @enderror
                 </div>
+                <div class="mb-3">
+                    <label for="name_en" class="form-label">Product Name (English)</label>
+                    <input type="text" class="form-control @error('name_en') is-invalid @enderror" id="name_en" name="name_en" value="{{ old('name_en', $product->name_en ?? '') }}">
+                    @error('name_en')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+                <div class="mb-3">
+                    <label for="name_ku" class="form-label">ناوی بەرهەم (کوردی)</label>
+                    <input type="text" class="form-control @error('name_ku') is-invalid @enderror" id="name_ku" name="name_ku" value="{{ old('name_ku', $product->name_ku ?? '') }}">
+                    @error('name_ku')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
 
                 {{-- ===== START: تم تعديل هذا القسم ===== --}}
                 <div class="mb-3">
                     <label for="description_ar" class="form-label">الوصف (عربي) <span class="text-danger">*</span></label>
                     <textarea class="form-control @error('description_ar') is-invalid @enderror" id="description_ar" name="description_ar" rows="5" required>{{ old('description_ar', $product->description_ar ?? '') }}</textarea>
                     @error('description_ar')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+                <div class="mb-3">
+                    <label for="description_en" class="form-label">Description (English)</label>
+                    <textarea class="form-control @error('description_en') is-invalid @enderror" id="description_en" name="description_en" rows="5">{{ old('description_en', $product->description_en ?? '') }}</textarea>
+                    @error('description_en')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+                <div class="mb-3">
+                    <label for="description_ku" class="form-label">وەسف (کوردی)</label>
+                    <textarea class="form-control @error('description_ku') is-invalid @enderror" id="description_ku" name="description_ku" rows="5">{{ old('description_ku', $product->description_ku ?? '') }}</textarea>
+                    @error('description_ku')
                         <div class="invalid-feedback">{{ $message }}</div>
                     @enderror
                 </div>
@@ -136,23 +164,27 @@
 {{-- ===== START: تم إضافة هذه السكربتات ===== --}}
 <script src="https://cdn.tiny.cloud/1/du3z85vklq5w3g8vsio7qztxeemn1ljmqzedt7n5vndlf6e1/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
 <script>
-    tinymce.init({
-        selector: '#description_ar',
-        plugins: 'directionality link image code lists',
-        toolbar: 'undo redo | blocks | bold italic | alignleft aligncenter alignright alignjustify | ltr rtl | bullist numlist | link image | code',
-        directionality: 'rtl',
-        height: 300,
-        menubar: false,
+    ['#description_ar', '#description_en', '#description_ku'].forEach(function(sel) {
+        if(document.querySelector(sel)) {
+            tinymce.init({
+                selector: sel,
+                plugins: 'directionality link image code lists',
+                toolbar: 'undo redo | blocks | bold italic | alignleft aligncenter alignright alignjustify | ltr rtl | bullist numlist | link image | code',
+                directionality: sel === '#description_en' ? 'ltr' : 'rtl',
+                height: 300,
+                menubar: false,
+            });
+        }
     });
 </script>
 {{-- ===== END: تم إضافة هذه السكربتات ===== --}}
 
 <script>
 document.addEventListener('DOMContentLoaded', function () {
-    // This is crucial to save the content from the editor before the form submits
-    const productForm = document.getElementById('description_ar').closest('form');
+    // Ensure TinyMCE content is saved before submitting
+    const productForm = document.querySelector('form');
     if (productForm) {
-        productForm.addEventListener('submit', function(e) {
+        productForm.addEventListener('submit', function () {
             tinymce.triggerSave();
         });
     }

--- a/resources/views/frontend/cart/index.blade.php
+++ b/resources/views/frontend/cart/index.blade.php
@@ -6,6 +6,7 @@
 <div class="bg-gray-50 min-h-screen"
     x-data='{
         cartItems: @json($cartItems),
+        locale: '{{ app()->getLocale() }}',
         subtotal: {{ $total }},
         discount: {{ $discountValue }},
         shippingCost: {{ $shippingCost }},
@@ -137,12 +138,12 @@
                         <template x-for="item in Object.values(cartItems)" :key="item.product.id">
                             <div class="bg-white rounded-lg shadow-sm p-4 flex gap-4">
                                 <a :href="`/product/${item.product.id}`" class="w-24 h-24 flex-shrink-0">
-                                    <img :src="item.product.first_image ? `/storage/${item.product.first_image.image_path}` : 'https://placehold.co/150x150?text=No+Image'" :alt="item.product.name_ar" class="w-full h-full object-cover rounded-md">
+                                    <img :src="item.product.first_image ? `/storage/${item.product.first_image.image_path}` : 'https://placehold.co/150x150?text=No+Image'" :alt="item.product['name_'+locale] || item.product.name_ar" class="w-full h-full object-cover rounded-md">
                                 </a>
                                 <div class="flex flex-col flex-grow w-full">
                                     <div class="flex justify-between items-start">
                                         <div>
-                                            <a :href="`/product/${item.product.id}`" class="font-bold text-lg text-brand-text hover:text-brand-primary" x-text="item.product.name_ar"></a>
+                                            <a :href="`/product/${item.product.id}`" class="font-bold text-lg text-brand-text hover:text-brand-primary" x-text="item.product['name_'+locale] || item.product.name_ar"></a>
                                             <p class="text-sm text-gray-500">SKU: <span x-text="item.product.sku || 'N/A'"></span></p>
                                         </div>
                                         <button @click="removeItem(item.product.id)" class="text-gray-400 hover:text-red-500 transition" title="إزالة المنتج">

--- a/resources/views/frontend/checkout/index.blade.php
+++ b/resources/views/frontend/checkout/index.blade.php
@@ -112,9 +112,9 @@
                     @foreach($cartItems as $item)
                         <div class="flex justify-between items-center text-sm">
                             <div class="flex items-center gap-3">
-                                <img src="{{ $item['product']->firstImage ? asset('storage/' . $item['product']->firstImage->image_path) : 'https://placehold.co/60x60' }}" alt="{{ $item['product']->name_ar }}" class="w-12 h-12 rounded-md object-cover">
+                                <img src="{{ $item['product']->firstImage ? asset('storage/' . $item['product']->firstImage->image_path) : 'https://placehold.co/60x60' }}" alt="{{ $item['product']->name_translated }}" class="w-12 h-12 rounded-md object-cover">
                                 <div>
-                                    <p class="text-gray-800 font-semibold">{{ $item['product']->name_ar }}</p>
+                                    <p class="text-gray-800 font-semibold">{{ $item['product']->name_translated }}</p>
                                     <p class="text-gray-500">الكمية: {{ $item['quantity'] }}</p>
                                 </div>
                             </div>

--- a/resources/views/frontend/homepage.blade.php
+++ b/resources/views/frontend/homepage.blade.php
@@ -140,7 +140,7 @@
                     </a>
                     <div class="p-4 text-right">
                         <div class="flex justify-between items-start mb-2">
-                            <h3 class="font-semibold text-lg text-brand-dark">{{ $product->name_ar }}</h3>
+                            <h3 class="font-semibold text-lg text-brand-dark">{{ $product->name_translated }}</h3>
                             @auth
                             <button 
                                 @click.prevent="
@@ -244,7 +244,7 @@
                     </a>
                     <div class="p-4 text-right">
                         <div class="flex justify-between items-start mb-2">
-                            <h3 class="font-semibold text-lg text-brand-dark">{{ $product->name_ar }}</h3>
+                            <h3 class="font-semibold text-lg text-brand-dark">{{ $product->name_translated }}</h3>
                             @auth
                             <button @click.prevent="
                                     loadingFav = true;
@@ -339,7 +339,7 @@
                     </a>
                     <div class="p-4 text-right">
                         <div class="flex justify-between items-start mb-2">
-                            <h3 class="font-semibold text-lg text-brand-dark">{{ $product->name_ar }}</h3>
+                            <h3 class="font-semibold text-lg text-brand-dark">{{ $product->name_translated }}</h3>
                             @auth
                             <button @click.prevent="
                                     loadingFav = true;

--- a/resources/views/frontend/partials/product_card.blade.php
+++ b/resources/views/frontend/partials/product_card.blade.php
@@ -15,7 +15,7 @@
     </a>
     <div class="p-4 text-right">
         <div class="flex justify-between items-start mb-2">
-            <h3 class="font-semibold text-lg text-brand-dark">{{ $product->name_ar }}</h3>
+            <h3 class="font-semibold text-lg text-brand-dark">{{ $product->name_translated }}</h3>
             @auth
             <button 
                 @click.prevent="

--- a/resources/views/frontend/product-detail.blade.php
+++ b/resources/views/frontend/product-detail.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', $product->name_ar)
+@section('title', $product->name_translated)
 
 @push('styles')
 <style>
@@ -49,7 +49,7 @@
             <div class="md:col-span-2 flex flex-col gap-4">
                 <div class="bg-white p-2 rounded-lg shadow-md border border-gray-200">
                     <button @click="imageZoomOpen = true" class="w-full cursor-zoom-in">
-                        <img :src="mainImage" alt="{{ $product->name_ar }}"
+                        <img :src="mainImage" alt="{{ $product->name_translated }}"
                              class="w-full h-auto aspect-square object-contain rounded-lg">
                     </button>
                 </div>
@@ -72,7 +72,7 @@
                     <a href="{{ route('shop') }}" class="hover:text-brand-primary">المتجر</a> / 
                     <a href="{{ route('shop', ['category' => $product->category->slug]) }}" class="hover:text-brand-primary">{{ $product->category->name_ar }}</a>
                 </div>
-                <h1 class="text-3xl lg:text-4xl font-bold text-brand-text mb-3">{{ $product->name_ar }}</h1>
+                <h1 class="text-3xl lg:text-4xl font-bold text-brand-text mb-3">{{ $product->name_translated }}</h1>
                 <span class="text-sm text-gray-500 mb-4">SKU: {{ $product->sku ?? 'N/A' }}</span>
 
                 <div class="mb-6">
@@ -155,7 +155,7 @@
 
                 <div class="prose max-w-none text-gray-700 leading-relaxed border-t border-gray-200 pt-8">
                     <h3 class="font-bold text-xl mb-4">الوصف</h3>
-                    {!! $product->description_ar !!}
+                    {!! $product->description_translated !!}
                 </div>
             </div>
 
@@ -208,7 +208,7 @@
                     </a>
                     <div class="p-4 text-right">
                         <div class="flex justify-between items-start mb-2">
-                            <h3 class="font-semibold text-lg text-brand-dark">{{ $relatedProduct->name_ar }}</h3>
+                            <h3 class="font-semibold text-lg text-brand-dark">{{ $relatedProduct->name_translated }}</h3>
                             @auth
                             <button 
                                 @click.prevent="

--- a/resources/views/frontend/product/show.blade.php
+++ b/resources/views/frontend/product/show.blade.php
@@ -1,23 +1,23 @@
 @extends('layouts.app')
 
-@section('title', $product->name_ar)
+@section('title', $product->name_translated)
 
 @section('content')
 <div class="container mx-auto px-4 py-12">
     <div class="grid grid-cols-1 md:grid-cols-2 gap-10">
         <!-- صورة المنتج -->
         <div>
-            <img src="{{ asset('storage/' . $product->image_url) }}" alt="{{ $product->name_ar }}" class="w-full h-64 object-cover rounded mb-4">
+            <img src="{{ asset('storage/' . $product->image_url) }}" alt="{{ $product->name_translated }}" class="w-full h-64 object-cover rounded mb-4">
         </div>
 
         <!-- تفاصيل المنتج -->
         <div>
-            <h1 class="text-3xl font-bold text-brand-text mb-4">{{ $product->name_ar }}</h1>
+            <h1 class="text-3xl font-bold text-brand-text mb-4">{{ $product->name_translated }}</h1>
             <p class="text-brand-primary text-2xl font-semibold mb-6">
                 {{ number_format($product->price, 0, ',', '.') }} د.ع
             </p>
             <p class="text-gray-700 leading-relaxed mb-6">
-                {{ $product->description_ar }}
+                {{ $product->description_translated }}
             </p>
 
             <form action="{{ route('cart.store') }}" method="POST">

--- a/resources/views/frontend/profile/order-details.blade.php
+++ b/resources/views/frontend/profile/order-details.blade.php
@@ -171,11 +171,11 @@
     <div class="space-y-2 md:space-y-3">
         @foreach($order->items as $item)
         <div class="flex items-center gap-3 p-2 md:p-3 border border-[#eadbcd] rounded-lg product-item">
-            <img src="{{ $item->product?->firstImage ? asset('storage/' . $item->product->firstImage->image_path) : 'https://placehold.co/80x80/f9f5f1/cd8985?text=Img' }}" 
-                 alt="{{ $item->product->name_ar ?? 'منتج' }}" 
+            <img src="{{ $item->product?->firstImage ? asset('storage/' . $item->product->firstImage->image_path) : 'https://placehold.co/80x80/f9f5f1/cd8985?text=Img' }}"
+                 alt="{{ $item->product->name_translated ?? 'منتج' }}"
                  class="w-16 h-16 md:w-20 md:h-20 rounded-md object-cover product-image">
             <div class="flex-grow">
-                <p class="font-semibold text-[#4a3f3f] text-sm md:text-base">{{ $item->product->name_ar ?? 'منتج محذوف' }}</p>
+                <p class="font-semibold text-[#4a3f3f] text-sm md:text-base">{{ $item->product->name_translated ?? 'منتج محذوف' }}</p>
                 <p class="text-[#7a6e6e] text-xs md:text-sm">الكمية: {{ $item->quantity }}</p>
             </div>
             <div class="text-left">

--- a/resources/views/frontend/profile/orders.blade.php
+++ b/resources/views/frontend/profile/orders.blade.php
@@ -133,8 +133,8 @@
                         <div class="flex items-center gap-2 md:gap-3 overflow-x-auto pb-2 scrollbar-hide">
                             @foreach($order->items->take(5) as $item)
                                 @if($item->product)
-                                <img src="{{ $item->product->firstImage ? asset('storage/' . $item->product->firstImage->image_path) : 'https://placehold.co/80x80/f9f5f1/cd8985?text=Img' }}" 
-                                     alt="{{ $item->product->name_ar }}" 
+                                <img src="{{ $item->product->firstImage ? asset('storage/' . $item->product->firstImage->image_path) : 'https://placehold.co/80x80/f9f5f1/cd8985?text=Img' }}"
+                                     alt="{{ $item->product->name_translated }}"
                                      class="w-10 h-10 md:w-12 md:h-12 rounded-md object-cover border border-[#eadbcd] flex-shrink-0">
                                 @endif
                             @endforeach

--- a/resources/views/frontend/profile/wishlist.blade.php
+++ b/resources/views/frontend/profile/wishlist.blade.php
@@ -113,7 +113,7 @@
                     </a>
                     <div class="p-3 md:p-4 text-right product-info">
                         <div class="flex justify-between items-start mb-2">
-                            <h3 class="font-semibold text-base md:text-lg text-[#4a3f3f] product-title">{{ $product->name_ar }}</h3>
+                            <h3 class="font-semibold text-base md:text-lg text-[#4a3f3f] product-title">{{ $product->name_translated }}</h3>
                             <button 
                                 @click.prevent="
                                     loadingFav = true;

--- a/resources/views/frontend/shop.blade.php
+++ b/resources/views/frontend/shop.blade.php
@@ -107,7 +107,7 @@
                         </a>
                         <div class="p-4 text-right">
                             <div class="flex justify-between items-start mb-2">
-                                <h3 class="font-semibold text-lg text-brand-dark">{{ $product->name_ar }}</h3>
+                                <h3 class="font-semibold text-lg text-brand-dark">{{ $product->name_translated }}</h3>
                                 @auth
                                 <button 
                                     @click.prevent="


### PR DESCRIPTION
## Summary
- allow English and Kurdish names/descriptions in product form
- accept optional translation fields in product controller validation
- expose `name_translated` and `description_translated` model attributes
- show translated values across admin and frontend pages

## Testing
- `php -l app/Http/Controllers/Admin/ProductController.php`
- `php -l app/Models/Product.php`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68874e6741d4832ca35397c5b873cdf3