### PR TITLE
Fix language attribute

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,9 @@
 <!DOCTYPE html>
-<html lang="ar" dir="rtl">
+@php
+    $locale = app()->getLocale();
+    $dir = in_array($locale, ['ar', 'ku']) ? 'rtl' : 'ltr';
+@endphp
+<html lang="{{ str_replace('_', '-', $locale) }}" dir="{{ $dir }}">
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -16,5 +16,6 @@ class HomepageResponseTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertSee('تسوقي الآن');
+        $response->assertSee('<html lang="ar"', false);
     }
 }


### PR DESCRIPTION
## Summary
- set `<html>` `lang` and `dir` dynamically from app locale
- ensure homepage test checks html `lang` attribute

## Testing
- `composer install` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68876b699c3c832cad55241babfb48e0