### PR TITLE
Update admin notifications role

### DIFF
--- a/app/Http/Controllers/Admin/OrderController.php
+++ b/app/Http/Controllers/Admin/OrderController.php
@@ -223,7 +223,8 @@ class OrderController extends Controller
             DB::commit();
 
             // إرسال إشعار للإدارة بوجود طلب جديد
-            $admins = User::role('admin')->get();
+            // Notify users with the Super-Admin role
+            $admins = User::role('Super-Admin')->get();
             foreach ($admins as $admin) {
                 $admin->notify(new NewOrderNotification($order));
             }

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -164,7 +164,8 @@ public function store(Request $request, InventoryService $inventoryService)
         DB::commit();
 
         // إشعارات الطلب الجديد
-        $admins = User::role('admin')->get();
+        // Notify users with the Super-Admin role
+        $admins = User::role('Super-Admin')->get();
         foreach ($admins as $admin) {
             $admin->notify(new NewOrderNotification($order));
         }


### PR DESCRIPTION
## Summary
- use the existing `Super-Admin` role when notifying admins

## Testing
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887b6226dd8832ca97ec45002cadff9